### PR TITLE
NetSuite handle salesorder transaction not found issue

### DIFF
--- a/src/adapters/netsuite/index.js
+++ b/src/adapters/netsuite/index.js
@@ -211,13 +211,17 @@ async function findContact({ user, authHeader, phoneNumber, overridingFormat }) 
                 });
             if (customerInfo.data.items.length > 0) {
                 for (var result of customerInfo.data.items) {
-                    const salesOrderResponse = await findSalesOrdersAgainstContact({ user, authHeader, contactId: result.id });
                     let salesOrders = [];
-                    for (const salesOrder of salesOrderResponse?.data?.items) {
-                        salesOrders.push({
-                            const: salesOrder?.id,
-                            title: salesOrder?.trandisplayname
-                        });
+                    try {
+                        const salesOrderResponse = await findSalesOrdersAgainstContact({ user, authHeader, contactId: result.id });
+                        for (const salesOrder of salesOrderResponse?.data?.items) {
+                            salesOrders.push({
+                                const: salesOrder?.id,
+                                title: salesOrder?.trandisplayname
+                            });
+                        }
+                    } catch (e) {
+                        console.log({ message: "Error in SalesOrder search" });
                     }
                     let firstName = result.firstname ?? '';
                     let middleName = result.middlename ?? '';
@@ -246,6 +250,7 @@ async function findContact({ user, authHeader, phoneNumber, overridingFormat }) 
             matchedContactInfo,
         };
     } catch (error) {
+        console.log({ message: "Error in finding contact", error });
         let errorMessage = netSuiteErrorDetails(error, "Contact not found");
         errorMessage += ' OR Permission violation: You need the "Lists -> Contact -> FULL, Lists -> Customers -> FULL" permission to access this page.';
         return {


### PR DESCRIPTION
On NetSuite Version 2025.1, executing a SalesOrder query requires an additional permission for custom roles: Find Transaction. If a user lacks this permission, they will encounter an error, and the call log will not be generated. To ensure seamless call logging without relying on SalesOrder handling, it is necessary to address this permission requirement proactively.
<img width="1716" alt="Screenshot 2025-03-05 at 2 32 59 PM" src="https://github.com/user-attachments/assets/f225d81e-72ed-43ef-ba99-b874d1e65f8d" />
